### PR TITLE
styling overview chart info, added % for process cpu

### DIFF
--- a/lib/scout_realtime/models/processes.rb
+++ b/lib/scout_realtime/models/processes.rb
@@ -1,7 +1,7 @@
 class Scout::Realtime::Processes < Scout::Realtime::Metric
   include Scout::Realtime::MultiAggregator
 
-  FIELDS = { :cpu              => {'label'=>'CPU usage', 'units'=>'', 'precision'=>2},
+  FIELDS = { :cpu              => {'label'=>'CPU usage', 'units'=>'%', 'precision'=>2},
              :memory           => {'units'=>'MB', 'precision'=>1},
              :count            => {'units'=>'', 'precision'=>0}
            }

--- a/lib/scout_realtime/web/javascripts/application.js
+++ b/lib/scout_realtime/web/javascripts/application.js
@@ -126,7 +126,6 @@ var Processes={
       $.each(bufferedData, function(data_index, value) {
         data.push({time: startTime + data_index * 1000, value: [value]})
       });
-
       chart = new lineChart({ element: $(this).get(0), data: data, metadata: meta.processes[metric] });
       chart.draw();
       Processes.index[cmd][metric] = chart;
@@ -185,8 +184,7 @@ function init() {
 
         data.push({time: startTime + data_index * 1000, value: [valueSum], valueBreakdown: valueBreakdown})
       });
-
-      chart = new lineChart({ element: $chart.get(0), data: data, yScaleMax: yScaleMax, metadata: meta[collector][chartMetrics[0]] });
+      chart = new lineChart({ element: $chart.get(0), data: data, yScaleMax: yScaleMax, metadata: (chartMetrics.length > 1 ? meta[collector] : meta[collector][chartMetrics[0]]) });
       chart.draw();
       graphs[id] = chart;
     } else {

--- a/lib/scout_realtime/web/javascripts/d3.linechart.js
+++ b/lib/scout_realtime/web/javascripts/d3.linechart.js
@@ -3,6 +3,9 @@ function lineChart(params) {
   this.yScaleMax = params.yScaleMax;
   this.element = params.element;
   this.metadata = params.metadata;
+	// charts can plot multiple metrics. if so, we assume units are the same. fetch that data from the first metric.
+	this.shared_metadata = ('units' in this.metadata ? this.metadata : this.metadata[Object.keys(this.metadata)[0]]);
+	
 	var line, path, x, y, barWidth, height, selection, chartInfo, latestValue, chartId;
 	
   this.draw = function() {
@@ -53,14 +56,21 @@ function lineChart(params) {
         .attr("width", barWidth)
         .attr("height", height)
         .attr("transform", function(d, i) { return "translate(" + (x(d.time) - barWidth) + ",0)"; })
+				// for overview charts, the latest value stays visible and the mouseover values appear beneath the chart. 
+				// because of space constraints, the latest value is hidden in process charts and the mouseover value takes its place.
         .on("mouseover", function(d) {
-          //latestValue.html(_this.format(d.value[0]));
-          chartInfo.html(_this.tooltip(d)).show();
-					latestValue.hide();
+          chartInfo.html(_this.tooltip(d))
+					if (chartInfo.css('display') == 'none') {
+						latestValue.hide();
+						chartInfo.show();
+					}
         })
         .on("mouseout", function(d) {
-          chartInfo.html("").hide();
-					latestValue.show();
+          chartInfo.html("")
+					if (latestValue.css('display') == 'none') {
+						latestValue.show();
+						chartInfo.hide();
+					}
         });
 
 		path = selection.append("g")
@@ -150,18 +160,23 @@ function lineChart(params) {
   }
 
   this.format = function(value) {
-    var formattedUnits = ( this.metadata.units == '%' ? '%' : '&nbsp;' + this.metadata.units )
-    return(value.toFixed(this.metadata.precision) + formattedUnits);
+    var formattedUnits = ( this.shared_metadata.units == '%' ? '%' : '&nbsp;' + this.shared_metadata.units )
+    return(value.toFixed(this.shared_metadata.precision) + formattedUnits);
   }
 
   this.tooltip = function(data) {
     var tooltipStr = '';
-    if(data.valueBreakdown) {
+		// if multiple values (ex: io wait, system, user), display the metric label + value. otherwise,
+		// just display the value.
+    if(data.valueBreakdown && Object.keys(data.valueBreakdown).length > 1) {
       for(var key in data.valueBreakdown) {
-        tooltipStr += key + ': ' + this.format(data.valueBreakdown[key]) + '; ';
+				var label = ('units' in this.metadata ? this.metadata.label : this.metadata[key].label);
+				if (!label) { label = key };
+				// metrics aren't guarenteed to have a label. use it if they do.
+        tooltipStr += '<span>'+label + '&nbsp;' + this.format(data.valueBreakdown[key]) + '</span>';
       }
     } else {
-      tooltipStr = this.format(data.value[0]);
+      tooltipStr = '<span>'+this.format(data.value[0])+'</span>';
     }
     return tooltipStr;
   }

--- a/lib/scout_realtime/web/stylesheets/styles.css
+++ b/lib/scout_realtime/web/stylesheets/styles.css
@@ -117,10 +117,6 @@ svg .line {
 	margin:0;
 }
 
-#top .chart_container{
-	margin-bottom: 20px;
-}
-
 /* sidebar */
 
 #sidebar_top, #sidebar_bottom.col-md-4 {
@@ -169,10 +165,14 @@ svg .line {
 }
 
 /** overview charts **/
+
+*.chart_container {
+	margin-bottom: 20px;
+}
+
 .chart {
   height:55px;
   width:100%;
-  cursor:crosshair;
 }
 
 .chart_container h3 {
@@ -182,19 +182,29 @@ svg .line {
 	float: left;
 }
 
-.chart_container .latest_value {
+.chart_container .latest_value{
   color: #000;
   font-size: 18px;
   font-weight: bold;
   float: right;
+  margin-top:-5px;
 }
 
-.chart_container .chart_info {
+*.chart_container .chart_info {
   font-size: 0.8em;
   height: 1em;
   color: #000;
   position: relative;
-  top: -15px;
+	font-weight: bold;
+	margin-right: 10px;
+	float: right;
+}
+
+*.chart_container .chart_info span {
+	background: lightgray;
+	border-radius: 3px;
+	margin-left: 10px;
+	padding: 2px 5px;
 }
 
 .chart_section {

--- a/lib/scout_realtime/web/views/graph.erb
+++ b/lib/scout_realtime/web/views/graph.erb
@@ -1,6 +1,4 @@
 <div class="chart_container">
   <svg class="chart overview_chart" data-collector="<%=chart_collector%>" data-metrics=<%= JSON.dump(chart_metrics) %> data-instance-name="<%=chart_instance_name%>" data-y_scale_max="<%= chart_y_scale_max %>"></svg>
-
-  <div class="chart_legend"></div>
   <div style="clear:both;"></div>
 </div>

--- a/lib/scout_realtime/web/views/overview_charts.erb
+++ b/lib/scout_realtime/web/views/overview_charts.erb
@@ -3,14 +3,14 @@
   <div class="col-md-6 chart_container">
     <h3>CPU Usage</h3>
     <div class="latest_value"></div>
-    <%= erb :graph, :locals => {:chart_collector => "cpu", :chart_metrics => ["io_wait", "system", "user"], :chart_instance_name => "", :chart_y_scale_max => "100"} %>
     <div class="chart_info"></div>
+    <%= erb :graph, :locals => {:chart_collector => "cpu", :chart_metrics => ["io_wait", "system", "user"], :chart_instance_name => "", :chart_y_scale_max => "100"} %>
   </div>
   <div class="col-md-6 chart_container">
     <h3>Memory Usage</h3>
     <div class="latest_value"></div>
-    <%= erb :graph, :locals => {:chart_collector => "memory", :chart_metrics => ["used_percent"], :chart_instance_name => "", :chart_y_scale_max => "100"} %>
     <div class="chart_info"></div>
+    <%= erb :graph, :locals => {:chart_collector => "memory", :chart_metrics => ["used_percent"], :chart_instance_name => "", :chart_y_scale_max => "100"} %>
   </div>
 </div> <!-- end first row of metrics -->
 <!-- bottom row of metrics -->
@@ -18,13 +18,13 @@
   <div class="col-md-6 chart_container">
     <h3>Disk Utilization</h3>
     <div class="latest_value"></div>
-    <%= erb :graph, :locals => {:chart_collector => "disk", :chart_metrics => ["utilization"], :chart_instance_name => @disks.last, :chart_y_scale_max => "100"} %>
     <div class="chart_info"></div>
+    <%= erb :graph, :locals => {:chart_collector => "disk", :chart_metrics => ["utilization"], :chart_instance_name => @disks.last, :chart_y_scale_max => "100"} %>
   </div>
   <div class="col-md-6 chart_container">
     <h3>Network Traffic</h3>
     <div class="latest_value"></div>
-    <%= erb :graph, :locals => {:chart_collector => "network", :chart_metrics => ["bytes_in", "bytes_out"], :chart_instance_name => @networks.first, :chart_y_scale_max => ""} %>
     <div class="chart_info"></div>
+    <%= erb :graph, :locals => {:chart_collector => "network", :chart_metrics => ["bytes_in", "bytes_out"], :chart_instance_name => @networks.first, :chart_y_scale_max => ""} %>
   </div> <!--  -->
 </div> <!-- end bottom row of metrics -->


### PR DESCRIPTION
First shot at some styling for the overview chart mouseovers:

![scout realtime-1](https://f.cloud.github.com/assets/7880/2033631/7d8101ae-891f-11e3-9e3a-2634edb6ab0d.jpg)

Also:
- Added "%" units for process cpu usage
- Modified `d3.linechart.js` to handle accepting metadata for multiple metrics
