### PR TITLE
Using TTL, set interval to 3 seconds, using cpu :skip_load option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.5
+
+* Using the `server_metrics` Collector `TTL` option for better performance on system calls.
+* Set runner interval to 3 seconds
+* Using CPU `:skip_load => true` option as load average info is not displayed. Collecting this involves a system call.
+
 ## 0.5.4
 
 * Misc UI updates

--- a/lib/scout_realtime/main.rb
+++ b/lib/scout_realtime/main.rb
@@ -1,7 +1,8 @@
 module Scout
   module Realtime
     class Main
-      INTERVAL=1
+      INTERVAL=3 # time in seconds between runs of the thread to fetch stats
+      TTL=60 # time in seconds for collectors to cache slow system commands
       LOG_NAME="realtime.log"
 
       attr_accessor :running, :runner, :stats_thread

--- a/lib/scout_realtime/models/cpu.rb
+++ b/lib/scout_realtime/models/cpu.rb
@@ -8,14 +8,13 @@ class Scout::Realtime::Cpu < Scout::Realtime::Metric
              :steal                 => { 'units' => '%', 'precision' => 1 },
              :interrupts            => { 'units' => '/sec', 'precision' => 1 },
              :procs_running         => { 'units' => '', 'precision' => 0 },
-             :procs_blocked         => { 'units' => '', 'precision' => 0 },
-             :last_minute           => { 'units' => '', 'precision' => 2 },
-             :last_five_minutes     => { 'units' => '', 'precision' => 2 },
-             :last_fifteen_minutes  => { 'units' => '', 'precision' => 2 } 
+             :procs_blocked         => { 'units' => '', 'precision' => 0 }
           }
 
   def initialize
-    @collector = ServerMetrics::Cpu.new()
+    # load average metrics aren't displayed in scout_realtime and the call to grab this is a system call,
+    # which is slow. avoids this.
+    @collector = ServerMetrics::Cpu.new(:skip_load => true)
     super
   end
 end

--- a/lib/scout_realtime/models/disk.rb
+++ b/lib/scout_realtime/models/disk.rb
@@ -15,7 +15,7 @@ class Scout::Realtime::Disk < Scout::Realtime::Metric
            }
 
   def initialize
-    @collector = ServerMetrics::Disk.new()
+    @collector = ServerMetrics::Disk.new(:ttl => Scout::Realtime::Main::TTL)
     super
   end
 end

--- a/lib/scout_realtime/version.rb
+++ b/lib/scout_realtime/version.rb
@@ -1,5 +1,5 @@
 module Scout
   module Realtime
-    VERSION = "0.5.4"
+    VERSION = "0.5.5.pre"
   end
 end

--- a/scout_realtime.gemspec
+++ b/scout_realtime.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   # Runtime dependencies
-  spec.add_runtime_dependency "server_metrics", "~> 1.1.1"
+  spec.add_runtime_dependency "server_metrics", "~> 1.2.0.pre"
 end


### PR DESCRIPTION
Some performance-related updates:
- Taking advantage of new options in `server_metrics` to use a `TTL` for slow system calls and skipping the cpu load average metrics as these are not displayed. 
- Using a 3-second runner interval.
