### PR TITLE
Aggregate Metrics for all Disks/Partitions

### DIFF
--- a/lib/scout_realtime/web/javascripts/application.js
+++ b/lib/scout_realtime/web/javascripts/application.js
@@ -183,9 +183,11 @@ function init() {
 
         $.each(chartMetrics, function(metric_index, metric) {
           var metricValue = dataSource[metric][data_index] || 0;
-          if (collector == 'disk')
-            for (var d in historical_metrics.disk)
+          if (collector == 'disk') {
+            for (var d in historical_metrics.disk) {
               metricValue += parseFloat(historical_metrics.disk[d].utilization[data_index]);
+            }
+          }
           valueBreakdown[metric] = metricValue;
           valueSum += metricValue;
         });
@@ -238,9 +240,11 @@ function updateGraphData() {
       var valueSum = 0;
       $.each(chartMetrics, function(metric_index, metric) {
         value = dataSource[metric] || 0;
-        if (collector == 'disk')
-          for (var d in metrics.disk)
+        if (collector == 'disk') {
+          for (var d in metrics.disk) {
             value += parseFloat(metrics.disk[d].utilization);
+          }
+        }
         valueBreakdown[metric] = value;
         valueSum += value;
       });
@@ -259,8 +263,7 @@ function updateGraphData() {
   $('#memory-used').html(parseInt(metrics.memory.used));
   $('#memory-size').html(parseInt(metrics.memory.size));
   var used = 0, size = 0;
-  for (var d in metrics.disk)
-  {
+  for (var d in metrics.disk) {
     used += parseInt(metrics.disk[d].used);
     size += parseInt(metrics.disk[d].size);
   }

--- a/lib/scout_realtime/web/javascripts/application.js
+++ b/lib/scout_realtime/web/javascripts/application.js
@@ -1,7 +1,7 @@
 var refreshInterval = 1000;
 var processIteration = 0;
 var firstShift = true;
-var overviewChartMargin = 30; // pulled from lineChart overview margin 
+var overviewChartMargin = 30; // pulled from lineChart overview margin
 function d(s){console.debug(s)}
 
 window.refresher = null;
@@ -151,7 +151,7 @@ $(document).ready(init);
 function init() {
   Processes.init({element:document.getElementById('processes')});
 	setOverviewChartWidths();
-	
+
 	$(window).on("debouncedresize", function( event ) {
 		setOverviewChartWidths();
 	});
@@ -183,6 +183,9 @@ function init() {
 
         $.each(chartMetrics, function(metric_index, metric) {
           var metricValue = dataSource[metric][data_index] || 0;
+          if (collector == 'disk')
+            for (var d in historical_metrics.disk)
+              metricValue += parseFloat(historical_metrics.disk[d].utilization[data_index]);
           valueBreakdown[metric] = metricValue;
           valueSum += metricValue;
         });
@@ -206,7 +209,7 @@ function init() {
   // setTimeout(updateGraphData, 1000) // uncomment to get ONE update in a second (for development)
   // normally, lines 1 and 2 above will be uncommented
 
-	// in chrome, the initial chart size is larger than what the parent container is. calling it here resets things. 
+	// in chrome, the initial chart size is larger than what the parent container is. calling it here resets things.
 	// still need to call it before drawing charts as FF won't draw it full width.
 	setOverviewChartWidths()
 
@@ -235,6 +238,9 @@ function updateGraphData() {
       var valueSum = 0;
       $.each(chartMetrics, function(metric_index, metric) {
         value = dataSource[metric] || 0;
+        if (collector == 'disk')
+          for (var d in metrics.disk)
+            value += parseFloat(metrics.disk[d].utilization);
         valueBreakdown[metric] = value;
         valueSum += value;
       });
@@ -252,8 +258,14 @@ function updateGraphData() {
   $('#report-time').html(formatTime(new Date));
   $('#memory-used').html(parseInt(metrics.memory.used));
   $('#memory-size').html(parseInt(metrics.memory.size));
-  $('#disk-used').html(parseInt(metrics.disk[Object.keys(metrics.disk)[0]].used));
-  $('#disk-size').html(parseInt(metrics.disk[Object.keys(metrics.disk)[0]].size));
+  var used = 0, size = 0;
+  for (var d in metrics.disk)
+  {
+    used += parseInt(metrics.disk[d].used);
+    size += parseInt(metrics.disk[d].size);
+  }
+  $('#disk-used').html(parseInt(used));
+  $('#disk-size').html(parseInt(size));
 }
 
 function formatTime(timestamp) {
@@ -284,7 +296,7 @@ function refresh() {
 /*
 Called on initial load. Just sets the svg element to the size of its parent. This is needed on firefox.
 
-Why don't we just use % widths for containers? 
+Why don't we just use % widths for containers?
 
 The chart SVGs have a 30px left margin to handle the y-axis. We need to shift the charts over 30px to the left
 to handle this. We also need to add 30px to the width of the chart so it ends up using the entire container width
@@ -299,7 +311,7 @@ function setOverviewChartWidths(){
 	$('.overview_chart_container').each(function(i,e) {
 		$(e).width(containerWidth).css('margin-right',padding)
 	});
-	
+
   $('.overview_chart').each(function(i,e){
     $svg=$(e);
     $svg.width(containerWidth+overviewChartMargin);


### PR DESCRIPTION
Show disk utilization and used/capacity cumulatively for all disks/partitions.

I noticed that only the used/size for / was shown, whereas I have /usr and /var as separate partitions, so I've just looped through the disk (historical) metrics to add all values from all partitions, instead of just the first disk object in the associative array.
