### PR TITLE
Fix copyright year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Andre Lewis
+Copyright (c) 2013-2014 Andre Lewis
 
 MIT License
 


### PR DESCRIPTION
Fix outdated copyright year (update to include 2014)
Copyright notices must include the current year. This commit updates the listed years to include 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
