### PR TITLE
Include server hostname in <title>

### DIFF
--- a/lib/scout_realtime/web/views/layout.erb
+++ b/lib/scout_realtime/web/views/layout.erb
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Scout Realtime</title>
+  <title>Scout Realtime &middot; <%= ServerMetrics::SystemInfo.hostname %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
This is helpful for when scout_realtime is running on multiple servers and I want to have each one open in a browser tab.
